### PR TITLE
List downloadOptions keys in docs for usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The component accepts the following props:
 |**`searchText`**|string||Initial search text
 |**`print`**|boolean|true|Show/hide print	 icon from toolbar
 |**`download`**|boolean|true|Show/hide download icon from toolbar
-|**`downloadOptions`**|object||Options to change the output of the CSV file. Default options: `{filename: 'tableDownload.csv', separator: ','}`
+|**`downloadOptions`**|object|`{filename: 'tableDownload.csv', separator: ','}`|Options to change the output of the CSV file: `filename`: string, `separator`: string, `filterOptions`: object(`useDisplayedColumnsOnly`: boolean, `useDisplayedRowsOnly`: boolean)
 |**`onDownload`**|function||A callback function that triggers when the user downloads the CSV file. In the callback, you can control what is written to the CSV file. `function(buildHead: (columns) => string, buildBody: (data) => string, columns, data) => string`. Return `false` to cancel download of file.
 |**`viewColumns`**|boolean|true|Show/hide viewColumns icon from toolbar
 |**`onRowsSelect`**|function||Callback function that triggers when row(s) are selected. `function(currentRowsSelected: array, allRowsSelected: array) => void`


### PR DESCRIPTION
I believe users would have an easier time using some customizations like `downloadOptions` if the allowed properties were listed in the documentation. If I want to customize how the CSV file will be output using `downloadOptions` but I only know about the default properties `filename` and `separator`, I will have no idea about other possible customizations enabled with `filterOptions` (like `useDisplayedColumnsOnly` and `useDisplayedRowsOnly`. I only found out about these because Dependabot listed them in the release notes.